### PR TITLE
Removed CalendarService from providers array property

### DIFF
--- a/app/pages/calendar/calendar.ts
+++ b/app/pages/calendar/calendar.ts
@@ -11,7 +11,7 @@ import {CalendarService} from '../../providers/calendar-service/calendar-service
 @Component({
   templateUrl: 'build/pages/calendar/calendar.html',
   // directives: [MyApp],
-  providers: [CalendarService],
+  providers: [],
 })
 export class CalendarPage {
   public posts: any;


### PR DESCRIPTION
Services/providers that are injected in the main app don't need to be added to each component's provider list as they are directly accessible from the constructor.